### PR TITLE
Add debouncer module for Problem2

### DIFF
--- a/Problem2/src/debouncer.v
+++ b/Problem2/src/debouncer.v
@@ -1,0 +1,26 @@
+module debouncer (
+  input      clk_i,
+  input      rst_ni,
+  input      btn_i,
+  output reg debounced_o
+);
+
+  reg [23:0] cnt;
+
+  always @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      cnt <= 24'hffffff;
+      debounced_o <= 1'b0;
+    end else begin
+      if (cnt == 24'hffffff) begin
+        if (btn_i != debounced_o) begin
+          debounced_o <= btn_i;
+          cnt <= 24'd0;
+        end
+      end else begin
+        cnt <= cnt + 24'd1;
+      end
+    end
+  end
+
+endmodule

--- a/Problem2/src/debouncer.v
+++ b/Problem2/src/debouncer.v
@@ -9,16 +9,20 @@ module debouncer (
 
   always @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      cnt <= 24'hffffff;
-      debounced_o <= 1'b0;
+      debounced_o <= btn_i;
+      cnt         <= 24'hffffff;
     end else begin
-      if (cnt == 24'hffffff) begin
+      if (&cnt) begin
         if (btn_i != debounced_o) begin
           debounced_o <= btn_i;
-          cnt <= 24'd0;
+          cnt         <= 24'd0;
+        end else begin
+          debounced_o <= debounced_o;
+          cnt         <= cnt;
         end
       end else begin
-        cnt <= cnt + 24'd1;
+        debounced_o <= debounced_o;
+        cnt         <= cnt + 24'd1;
       end
     end
   end

--- a/Problem2/src/debouncer_tb.v
+++ b/Problem2/src/debouncer_tb.v
@@ -1,3 +1,4 @@
+`timescale 1ns/1ps
 `include "debouncer.v"
 
 module debouncer_tb;
@@ -21,21 +22,22 @@ module debouncer_tb;
     #15;
     rst_n = 1;
     #17;
-    btn = #30 ~btn;
-    btn = #30 ~btn;
-    btn = #30 ~btn;
-    btn = #30 ~btn;
-    btn = #30 ~btn;
-    btn = #30 ~btn;
-    btn = #30 ~btn;
-    btn = #30 ~btn;
+    btn = #32 ~btn;
+    btn = #20 ~btn;
+    btn = #29 ~btn;
+    btn = #20 ~btn;
+    btn = #29 ~btn;
+    btn = #10 ~btn;
+    btn = #34 ~btn;
+    btn = #10 ~btn;
+    btn = #10 ~btn;
     btn = 1;
-    #50;
+    #200;
     $finish;
   end
 
   always begin
-    clk = #5 ~clk;
+    clk = #4 ~clk;
   end
 
   initial begin

--- a/Problem2/src/debouncer_tb.v
+++ b/Problem2/src/debouncer_tb.v
@@ -1,0 +1,46 @@
+`include "debouncer.v"
+
+module debouncer_tb;
+
+  reg clk;
+  reg rst_n;
+  reg btn;
+  wire debounced;
+
+  debouncer u_debouncer(
+    .clk_i      (clk),
+    .rst_ni     (rst_n),
+    .btn_i      (btn),
+    .debounced_o(debounced)
+  );
+
+  initial begin
+    clk = 0;
+    rst_n = 0;
+    btn = 0;
+    #15;
+    rst_n = 1;
+    #17;
+    btn = #30 ~btn;
+    btn = #30 ~btn;
+    btn = #30 ~btn;
+    btn = #30 ~btn;
+    btn = #30 ~btn;
+    btn = #30 ~btn;
+    btn = #30 ~btn;
+    btn = #30 ~btn;
+    btn = 1;
+    #50;
+    $finish;
+  end
+
+  always begin
+    clk = #5 ~clk;
+  end
+
+  initial begin
+    $dumpfile("debouncer.vcd");
+    $dumpvars;
+  end
+
+endmodule


### PR DESCRIPTION
The buttons on the FPGA board may need debouncing. This module can debounce the signal from buttons. The following figure is to show the simulation of the *bouncing* signal `btn` and its debounced signal `debounced`.

![image](https://user-images.githubusercontent.com/79467307/158576971-148f7be0-fa4a-4c83-bfa4-f6e267cfd832.png)
