### PR TITLE
Fix debouncer to generate 1-clock pulse signal

### DIFF
--- a/Problem2/src/controller.v
+++ b/Problem2/src/controller.v
@@ -175,21 +175,21 @@ end
 
 /* modify light sec */
 always@(*)begin  
-  if(BTN[1])begin // sec +1
+  if(debouncer_BTN[1])begin // sec +1
     if(&changed_light)begin
       new_light = changed_light;
     end else begin
       new_light = changed_light + 4'd1;
     end
   end  
-  else if(BTN[2])begin //sec -1
+  else if(debouncer_BTN[2])begin //sec -1
     if(~|changed_light)begin
       new_light = changed_light;
     end else begin
       new_light = changed_light - 4'd1;
     end
   end  
-  else if(BTN[0])begin //do reset
+  else if(debouncer_BTN[0])begin //do reset
     case(changed_light)
       rg_length:new_light = 4'd5;
       yellow_length:new_light = 4'd1;

--- a/Problem2/src/debouncer.v
+++ b/Problem2/src/debouncer.v
@@ -13,15 +13,15 @@ module debouncer (
       cnt         <= 24'hffffff;
     end else begin
       if (&cnt) begin
-        if (btn_i != debounced_o) begin
-          debounced_o <= btn_i;
+        if (btn_i == 1'b1) begin
+          debounced_o <= 1'b1;
           cnt         <= 24'd0;
         end else begin
-          debounced_o <= debounced_o;
+          debounced_o <= 1'b0;
           cnt         <= cnt;
         end
       end else begin
-        debounced_o <= debounced_o;
+        debounced_o <= 1'b0;
         cnt         <= cnt + 24'd1;
       end
     end

--- a/Problem2/src/debouncer_tb.v
+++ b/Problem2/src/debouncer_tb.v
@@ -4,23 +4,23 @@
 module debouncer_tb;
 
   reg clk;
-  reg rst_n;
+  reg rst;
   reg btn;
   wire debounced;
 
   debouncer u_debouncer(
     .clk_i      (clk),
-    .rst_ni     (rst_n),
+    .rst_i      (rst),
     .btn_i      (btn),
     .debounced_o(debounced)
   );
 
   initial begin
     clk = 0;
-    rst_n = 0;
+    rst = 1;
     btn = 0;
     #15;
-    rst_n = 1;
+    rst = 0;
     #17;
     btn = #32 ~btn;
     btn = #20 ~btn;


### PR DESCRIPTION
Since the #7 may be caused by the button signal, which can be pulled up for several clock cycles within a click (the clock is too quick), I revised the debouncer module so that when button is pressed, it generate a 1-clock signal to prevent this problem. Please see the waveform. The `debounced` signal is only pulled up for 1 clock cycle.

![image](https://user-images.githubusercontent.com/79467307/158981750-887a7491-6894-46aa-a58c-d7d7ad969b91.png)

Also, I reconnected the signal outputs from debouncer back to controller.