### PR TITLE
Change the clock of FSM to div_clk

### DIFF
--- a/Problem2/src/controller.v
+++ b/Problem2/src/controller.v
@@ -75,7 +75,7 @@ always@(*)begin
 end
 
 /* FSM */
-always@(posedge clk or posedge rst)begin
+always@(posedge div_clk or posedge rst)begin
   if(rst)begin
     state <= IDLE;
   end


### PR DESCRIPTION
By simulation result, changing the clock of FSM to `div_clk` may help fix the problem. See the simulation result below. The output shows the color of `led4` and `led5` and the value of `led`.

![image](https://user-images.githubusercontent.com/79467307/159013447-8be1c007-d167-49de-b712-ba5bd16db9d3.png)
